### PR TITLE
Improve debug logging

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,5 +12,5 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      intervale: "weekly"
+      interval: "weekly"
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -23,8 +23,11 @@ jobs:
           go-version-file: 'go.mod'
           cache: true
 
+      - name: Install Tools
+        run: make prep
+
       - name: Execute tests
-        run: make dev && make testacc
+        run: make test && make testacc
 
       - name: Upload test artifacts for debugging
         uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -25,7 +25,7 @@ test:
 testacc: dev
 	@PACKER_ACC=1 go test -count $(COUNT) -v $(TEST) -timeout=120m
 
-install-packer-sdc: ## Install packer sofware development command
+install-packer-sdc: ## Install packer software development command
 	@go install github.com/hashicorp/packer-plugin-sdk/cmd/packer-sdc@${HASHICORP_PACKER_PLUGIN_SDK_VERSION}
 
 ci-release-docs: install-packer-sdc

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -5,37 +5,50 @@ HASHICORP_PACKER_PLUGIN_SDK_VERSION?=$(shell go list -m github.com/hashicorp/pac
 COUNT?=1
 TEST?=$(shell go list ./...)
 
-.PHONY: dev
+prep: phony
+	go install honnef.co/go/tools/cmd/staticcheck@latest
 
-build:
+build: phony
 	@go build -o ${BINARY}
 
-dev: build
+dev: phony build
 	@mkdir -p ~/.packer.d/plugins/
 	@mv ${BINARY} ~/.packer.d/plugins/${BINARY}
 
-run-example: dev
+run-example: phony dev
 	@packer build ./example
 
-test:
-	@go test -race -count $(COUNT) $(TEST) -timeout=3m
+test: phony
+	go mod tidy
+	go fmt ./...
+	go vet ./...
+	staticcheck -checks="all" -tests ./...
+	go test -race -count $(COUNT) $(TEST) -timeout=3m
 
 # the acceptance tests have a weird habit of messing up the tty (e.g. turning off echo mode, so
 # terminal stops showing what you type). If this happens to you, run `reset` or `stty sane` to fix.
-testacc: dev
+testacc: phony dev
 	@PACKER_ACC=1 go test -count $(COUNT) -v $(TEST) -timeout=120m
 
-install-packer-sdc: ## Install packer software development command
+install-packer-sdc: phony ## Install packer software development command
 	@go install github.com/hashicorp/packer-plugin-sdk/cmd/packer-sdc@${HASHICORP_PACKER_PLUGIN_SDK_VERSION}
 
-ci-release-docs: install-packer-sdc
+ci-release-docs: phony install-packer-sdc
 	@packer-sdc renderdocs -src docs -partials docs-partials/ -dst docs/
 	@/bin/sh -c "[ -d docs ] && zip -r docs.zip docs/"
 
-plugin-check: install-packer-sdc build
+plugin-check: phony install-packer-sdc build
 	@packer-sdc plugin-check ${BINARY}
 
-generate: install-packer-sdc
+generate: phony install-packer-sdc
 	@go generate -v ./...
 	packer-sdc renderdocs -src ./docs -dst ./.docs -partials ./docs-partials
 	# see the .docs folder for a preview of the docs
+
+# instead of listing every target in .PHONY, we create one
+# 'phony' target which all the other targets depend on.
+# This saves me from having to remember to add each new target
+# to the .PHONY list, and is a little cleaner than putting
+# `.PHONY: target` before each target
+.PHONY: phony
+phony:

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Add the plugin to your packer config:
 packer {
   required_plugins {
     git = {
-      version = ">= 0.3.4"
+      version = ">= 0.3.5"
       source  = "github.com/ethanmdavidson/git"
     }
   }

--- a/README.md
+++ b/README.md
@@ -52,6 +52,6 @@ The typical development flow looks something like this:
 
 For local development, you will need to install:
 - [Packer](https://learn.hashicorp.com/tutorials/packer/get-started-install-cli) >= 1.7
-- [Go](https://golang.org/doc/install) >= 1.18
+- [Go](https://golang.org/doc/install) >= 1.19
 - Make
 `

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Add the plugin to your packer config:
 packer {
   required_plugins {
     git = {
-      version = ">=v0.3.2"
+      version = ">= 0.3.4"
       source  = "github.com/ethanmdavidson/git"
     }
   }

--- a/common/common.go
+++ b/common/common.go
@@ -1,0 +1,15 @@
+package common
+
+import (
+	"log"
+	"path/filepath"
+)
+
+func PrintOpeningRepo(path string) {
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		log.Printf("Finding repository from '%s' (unable to determine absolute path, %s)\n", path, err.Error())
+	} else {
+		log.Printf("Finding repository from '%s' (%s)\n", path, absPath)
+	}
+}

--- a/common/common.go
+++ b/common/common.go
@@ -1,3 +1,4 @@
+// Package common contains some logic that is shared by all datasources
 package common
 
 import (

--- a/datasource/commit/data.go
+++ b/datasource/commit/data.go
@@ -2,12 +2,14 @@
 package commit
 
 import (
+	"github.com/ethanmdavidson/packer-plugin-git/common"
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/hashicorp/hcl/v2/hcldec"
 	"github.com/hashicorp/packer-plugin-sdk/hcl2helper"
 	"github.com/hashicorp/packer-plugin-sdk/template/config"
 	"github.com/zclconf/go-cty/cty"
+	"log"
 )
 
 type Config struct {
@@ -53,45 +55,72 @@ func (d *Datasource) OutputSpec() hcldec.ObjectSpec {
 }
 
 func (d *Datasource) Execute() (cty.Value, error) {
+	log.Println("Starting execution")
 	output := DatasourceOutput{}
 	emptyOutput := hcl2helper.HCL2ValueFromConfig(output, d.OutputSpec())
 
+	common.PrintOpeningRepo(d.config.Path)
 	openOptions := &git.PlainOpenOptions{DetectDotGit: true}
 	repo, err := git.PlainOpenWithOptions(d.config.Path, openOptions)
 	if err != nil {
 		return emptyOutput, err
 	}
+	log.Println("Repo opened")
+
 	hash, err := repo.ResolveRevision(plumbing.Revision(d.config.CommitIsh))
 	if err != nil {
 		return emptyOutput, err
 	}
-	branches, err := repo.Branches()
+	log.Printf("Hash found: '%s'\n", hash.String())
+
+	branchIter, err := repo.Branches()
 	if err != nil {
 		return emptyOutput, err
 	}
-	branchesAtResolvedCommit := make([]string, 0)
-	_ = branches.ForEach(func(ref *plumbing.Reference) error {
-		if ref.Hash().String() == hash.String() {
-			branchesAtResolvedCommit = append(branchesAtResolvedCommit, ref.Name().Short())
-		}
-		return nil
-	})
+	log.Println("Branches found")
+
 	commit, err := repo.CommitObject(*hash)
 	if err != nil {
 		return emptyOutput, err
 	}
+	log.Printf("Commit found: '%s'\n", commit.String())
 
 	output.Hash = hash.String()
-	output.Branches = branchesAtResolvedCommit
+	log.Printf("output.Hash: '%s'\n", output.Hash)
+
+	output.Branches = make([]string, 0)
+	_ = branchIter.ForEach(func(ref *plumbing.Reference) error {
+		if ref.Hash().String() == hash.String() {
+			log.Printf("Adding branch '%s'\n", ref.Name().Short())
+			output.Branches = append(output.Branches, ref.Name().Short())
+		} else {
+			log.Printf("Not in branch '%s' (%s)\n", ref.Name().Short(), ref.Hash().String())
+		}
+		return nil
+	})
+	log.Printf("len(output.Branches): '%d'\n", len(output.Branches))
+
 	output.Author = commit.Author.String()
+	log.Printf("output.Author: '%s'\n", output.Author)
+
 	output.Committer = commit.Committer.String()
+	log.Printf("output.Committer: '%s'\n", output.Committer)
+
 	output.PGPSignature = commit.PGPSignature
+	log.Printf("len(output.PGPSignature): '%d'\n", len(output.PGPSignature))
+
 	output.Message = commit.Message
+	log.Printf("len(output.Message): '%d'\n", len(output.Message))
+
 	output.TreeHash = commit.TreeHash.String()
+	log.Printf("output.TreeHash: '%s'\n", output.TreeHash)
+
 	output.ParentHashes = make([]string, 0)
 	for _, parent := range commit.ParentHashes {
+		log.Printf("Adding parent hash: '%s'\n", parent.String())
 		output.ParentHashes = append(output.ParentHashes, parent.String())
 	}
+	log.Printf("len(output.ParentHashes): '%d'\n", len(output.ParentHashes))
 
 	return hcl2helper.HCL2ValueFromConfig(output, d.OutputSpec()), nil
 }

--- a/datasource/commit/data.go
+++ b/datasource/commit/data.go
@@ -1,3 +1,5 @@
+// Package commit contains logic for providing commit data to Packer
+//
 //go:generate packer-sdc mapstructure-to-hcl2 -type Config,DatasourceOutput
 package commit
 

--- a/datasource/commit/data_acc_test.go
+++ b/datasource/commit/data_acc_test.go
@@ -3,7 +3,7 @@ package commit
 import (
 	_ "embed"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"os/exec"
 	"regexp"
@@ -38,9 +38,11 @@ func TestAccGitCommitDatasource(t *testing.T) {
 			if err != nil {
 				return fmt.Errorf("Unable find %s", logfile)
 			}
-			defer logs.Close()
+			defer func(logs *os.File) {
+				_ = logs.Close()
+			}(logs)
 
-			logsBytes, err := ioutil.ReadAll(logs)
+			logsBytes, err := io.ReadAll(logs)
 			if err != nil {
 				return fmt.Errorf("Unable to read %s", logfile)
 			}

--- a/datasource/repository/data.go
+++ b/datasource/repository/data.go
@@ -2,12 +2,14 @@
 package repository
 
 import (
+	"github.com/ethanmdavidson/packer-plugin-git/common"
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/hashicorp/hcl/v2/hcldec"
 	"github.com/hashicorp/packer-plugin-sdk/hcl2helper"
 	"github.com/hashicorp/packer-plugin-sdk/template/config"
 	"github.com/zclconf/go-cty/cty"
+	"log"
 )
 
 type Config struct {
@@ -45,47 +47,69 @@ func (d *Datasource) OutputSpec() hcldec.ObjectSpec {
 }
 
 func (d *Datasource) Execute() (cty.Value, error) {
+	log.Println("Starting execution")
 	output := DatasourceOutput{}
 	emptyOutput := hcl2helper.HCL2ValueFromConfig(output, d.OutputSpec())
 
+	common.PrintOpeningRepo(d.config.Path)
 	openOptions := &git.PlainOpenOptions{DetectDotGit: true}
 	repo, err := git.PlainOpenWithOptions(d.config.Path, openOptions)
 	if err != nil {
 		return emptyOutput, err
 	}
+	log.Println("Repo opened")
+
 	head, err := repo.Head()
 	if err != nil {
 		return emptyOutput, err
 	}
+	log.Printf("Head found: '%s'\n", head.String())
+
 	worktree, err := repo.Worktree()
 	if err != nil {
 		return emptyOutput, err
 	}
+	log.Println("Worktree found")
+
 	status, err := worktree.Status()
 	if err != nil {
 		return emptyOutput, err
 	}
+	log.Printf("Worktree status found: '%s'\n", status.String())
+
 	branchIter, err := repo.Branches()
 	if err != nil {
 		return emptyOutput, err
 	}
+	log.Println("Branches found")
+
 	tagIter, err := repo.Tags()
 	if err != nil {
 		return emptyOutput, err
 	}
+	log.Println("Tags found")
 
 	output.Head = head.Name().Short()
+	log.Printf("output.Head: '%s'\n", output.Head)
+
 	output.IsClean = status.IsClean()
+	log.Printf("output.IsClean: '%s'\n", output.IsClean)
+
 	output.Branches = make([]string, 0)
 	_ = branchIter.ForEach(func(reference *plumbing.Reference) error {
+		log.Printf("Adding branch: '%s'\n", reference.Name().Short())
 		output.Branches = append(output.Branches, reference.Name().Short())
 		return nil
 	})
+	log.Printf("len(output.Branches): '%d'\n", len(output.Branches))
+
 	output.Tags = make([]string, 0)
 	_ = tagIter.ForEach(func(reference *plumbing.Reference) error {
+		log.Printf("Adding tag: '%s'\n", reference.Name().Short())
 		output.Tags = append(output.Tags, reference.Name().Short())
 		return nil
 	})
+	log.Printf("len(output.Tags): '%d'\n", len(output.Tags))
 
 	return hcl2helper.HCL2ValueFromConfig(output, d.OutputSpec()), nil
 }

--- a/datasource/repository/data.go
+++ b/datasource/repository/data.go
@@ -1,3 +1,5 @@
+// Package repository contains logic for providing repo data to Packer
+//
 //go:generate packer-sdc mapstructure-to-hcl2 -type Config,DatasourceOutput
 package repository
 
@@ -93,7 +95,7 @@ func (d *Datasource) Execute() (cty.Value, error) {
 	log.Printf("output.Head: '%s'\n", output.Head)
 
 	output.IsClean = status.IsClean()
-	log.Printf("output.IsClean: '%s'\n", output.IsClean)
+	log.Printf("output.IsClean: '%t'\n", output.IsClean)
 
 	output.Branches = make([]string, 0)
 	_ = branchIter.ForEach(func(reference *plumbing.Reference) error {

--- a/datasource/repository/data_acc_test.go
+++ b/datasource/repository/data_acc_test.go
@@ -3,7 +3,7 @@ package repository
 import (
 	_ "embed"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"os/exec"
 	"regexp"
@@ -38,9 +38,11 @@ func TestAccGitRepositoryDatasource(t *testing.T) {
 			if err != nil {
 				return fmt.Errorf("Unable find %s", logfile)
 			}
-			defer logs.Close()
+			defer func(logs *os.File) {
+				_ = logs.Close()
+			}(logs)
 
-			logsBytes, err := ioutil.ReadAll(logs)
+			logsBytes, err := io.ReadAll(logs)
 			if err != nil {
 				return fmt.Errorf("Unable to read %s", logfile)
 			}

--- a/datasource/tree/data.go
+++ b/datasource/tree/data.go
@@ -1,3 +1,5 @@
+// Package tree contains logic for providing working tree data to Packer
+//
 //go:generate packer-sdc mapstructure-to-hcl2 -type Config,DatasourceOutput
 package tree
 

--- a/datasource/tree/data.go
+++ b/datasource/tree/data.go
@@ -3,6 +3,8 @@ package tree
 
 import (
 	"errors"
+	"github.com/ethanmdavidson/packer-plugin-git/common"
+	"log"
 
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
@@ -50,35 +52,48 @@ func (d *Datasource) OutputSpec() hcldec.ObjectSpec {
 }
 
 func (d *Datasource) Execute() (cty.Value, error) {
+	log.Println("Starting execution")
 	output := DatasourceOutput{}
 	emptyOutput := hcl2helper.HCL2ValueFromConfig(output, d.OutputSpec())
 
+	common.PrintOpeningRepo(d.config.Path)
 	openOptions := &git.PlainOpenOptions{DetectDotGit: true}
 	repo, err := git.PlainOpenWithOptions(d.config.Path, openOptions)
 	if err != nil {
 		return emptyOutput, err
 	}
+	log.Println("Repo opened")
+
 	hash, err := repo.ResolveRevision(plumbing.Revision(d.config.CommitIsh))
 	if err != nil {
 		return emptyOutput, err
 	}
+	log.Printf("Hash found: '%s'\n", hash.String())
+
 	commit, err := repo.CommitObject(*hash)
 	if err != nil {
 		return emptyOutput, errors.New("couldn't find commit")
 	}
+	log.Printf("Commit found: '%s'\n", commit.String())
+
 	tree, err := commit.Tree()
 	if err != nil {
 		return emptyOutput, errors.New("couldn't find tree")
 	}
+	log.Println("Tree found")
 
 	output.Hash = hash.String()
+	log.Printf("output.Hash: '%s'\n", output.Hash)
+
 	output.Files = make([]string, 0)
 	_ = tree.Files().ForEach(func(file *object.File) error {
 		if file != nil {
+			log.Printf("Adding file: '%s'\n", file.Name)
 			output.Files = append(output.Files, file.Name)
 		}
 		return nil
 	})
+	log.Printf("len(output.Files): '%d'\n", len(output.Files))
 
 	return hcl2helper.HCL2ValueFromConfig(output, d.OutputSpec()), nil
 }

--- a/datasource/tree/data_acc_test.go
+++ b/datasource/tree/data_acc_test.go
@@ -3,7 +3,7 @@ package tree
 import (
 	_ "embed"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"os/exec"
 	"regexp"
@@ -38,9 +38,11 @@ func TestAccGitTreeDatasource(t *testing.T) {
 			if err != nil {
 				return fmt.Errorf("Unable find %s", logfile)
 			}
-			defer logs.Close()
+			defer func(logs *os.File) {
+				_ = logs.Close()
+			}(logs)
 
-			logsBytes, err := ioutil.ReadAll(logs)
+			logsBytes, err := io.ReadAll(logs)
 			if err != nil {
 				return fmt.Errorf("Unable to read %s", logfile)
 			}

--- a/docs/datasources/index.mdx
+++ b/docs/datasources/index.mdx
@@ -28,7 +28,7 @@ configuration to install this plugin. Then, run
 packer {
   required_plugins {
     git = {
-      version = ">= 0.3.4"
+      version = ">= 0.3.5"
       source = "github.com/ethanmdavidson/git"
     }
   }

--- a/docs/datasources/index.mdx
+++ b/docs/datasources/index.mdx
@@ -28,7 +28,7 @@ configuration to install this plugin. Then, run
 packer {
   required_plugins {
     git = {
-      version = ">= 0.3.2"
+      version = ">= 0.3.4"
       source = "github.com/ethanmdavidson/git"
     }
   }

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ethanmdavidson/packer-plugin-git
 
-go 1.18
+go 1.19
 
 require (
 	github.com/go-git/go-git/v5 v5.6.1

--- a/go.mod
+++ b/go.mod
@@ -74,7 +74,7 @@ require (
 	github.com/sergi/go-diff v1.2.0 // indirect
 	github.com/skeema/knownhosts v1.1.0 // indirect
 	github.com/ugorji/go/codec v1.2.7 // indirect
-	github.com/ulikunitz/xz v0.5.10 // indirect
+	github.com/ulikunitz/xz v0.5.11 // indirect
 	github.com/xanzy/ssh-agent v0.3.3 // indirect
 	go.uber.org/atomic v1.10.0 // indirect
 	golang.org/x/crypto v0.6.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -307,8 +307,8 @@ github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqri
 github.com/ugorji/go v1.2.7/go.mod h1:nF9osbDWLy6bDVv/Rtoh6QgnvNDpmCalQV5urGCCS6M=
 github.com/ugorji/go/codec v1.2.7 h1:YPXUKf7fYbp/y8xloBqZOw2qaVggbfwMlI8WM3wZUJ0=
 github.com/ugorji/go/codec v1.2.7/go.mod h1:WGN1fab3R1fzQlVQTkfxVtIBhWDRqOviHU95kRgeqEY=
-github.com/ulikunitz/xz v0.5.10 h1:t92gobL9l3HE202wg3rlk19F6X+JOxl9BBrCCMYEYd8=
-github.com/ulikunitz/xz v0.5.10/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
+github.com/ulikunitz/xz v0.5.11 h1:kpFauv27b6ynzBNT/Xy+1k+fK4WswhN/6PN5WhFAGw8=
+github.com/ulikunitz/xz v0.5.11/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
 github.com/vmihailenco/msgpack/v4 v4.3.12/go.mod h1:gborTTJjAo/GWTqqRjrLCn9pgNN+NXzzngzBKDPIqw4=
 github.com/vmihailenco/tagparser v0.1.1/go.mod h1:OeAg3pn3UbLjkWt+rN9oFYB6u/cQgqMEUPoW2WPyhdI=
 github.com/xanzy/ssh-agent v0.3.3 h1:+/15pJfg/RsTxqYcX6fHqOXZwwMP+2VyYWJeWM2qQFM=

--- a/main.go
+++ b/main.go
@@ -13,7 +13,7 @@ import (
 
 var (
 	// Version is the main version number that is being run at the moment.
-	Version = "0.3.2"
+	Version = "0.3.4"
 
 	// VersionPrerelease is A pre-release marker for the Version. If this is ""
 	// (empty string) then it means that it is a final release. Otherwise, this

--- a/main.go
+++ b/main.go
@@ -13,7 +13,7 @@ import (
 
 var (
 	// Version is the main version number that is being run at the moment.
-	Version = "0.3.4"
+	Version = "0.3.5"
 
 	// VersionPrerelease is A pre-release marker for the Version. If this is ""
 	// (empty string) then it means that it is a final release. Otherwise, this
@@ -33,7 +33,7 @@ func main() {
 	pps.SetVersion(PluginVersion)
 	err := pps.Run()
 	if err != nil {
-		fmt.Fprintln(os.Stderr, err.Error())
+		_, _ = fmt.Fprintln(os.Stderr, err.Error())
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
Also some misc changes:
- upgrade to go 1.19
- upgrade indirect dependency that has published vuln
- get version numbers up to date
- use `staticcheck` and `go vet`
- explicitly ignore error that we don't need to handle
- run unit tests in 'run tests' workflow (in addition to acceptance tests)
- fix typo in dependabot config

(this PR got a little bigger than it should have. I need to get better about splitting things up)