### PR TITLE
add `timestamp` to commit datasource

### DIFF
--- a/.web-docs/components/data-source/commit/README.md
+++ b/.web-docs/components/data-source/commit/README.md
@@ -27,6 +27,7 @@ for the list of supported values. Defaults to 'HEAD'.
 - `branches` (string) - The short names of branches at the selected commit.
 - `author` (string) - The author of the commit, in standard `A U Thor <author@example.com>` format.
 - `committer` (string) - The committer of the commit, in same format as author.
+- `timestamp` (string) - The timestamp of the commit, in RFC3339 format.
 - `pgp_signature` (string) - The PGP signature attached to the commit.
 - `message` (string) - The commit message.
 - `tree_hash` (string) - The hash of the root tree of the commit.

--- a/.web-docs/components/data-source/commit/README.md
+++ b/.web-docs/components/data-source/commit/README.md
@@ -27,7 +27,7 @@ for the list of supported values. Defaults to 'HEAD'.
 - `branches` (string) - The short names of branches at the selected commit.
 - `author` (string) - The author of the commit, in standard `A U Thor <author@example.com>` format.
 - `committer` (string) - The committer of the commit, in same format as author.
-- `timestamp` (string) - The timestamp of the commit, in RFC3339 format.
+- `timestamp` (string) - The timestamp of the commit, in RFC3339 format (e.g. `2024-01-02T09:38:19Z`).
 - `pgp_signature` (string) - The PGP signature attached to the commit.
 - `message` (string) - The commit message.
 - `tree_hash` (string) - The hash of the root tree of the commit.

--- a/datasource/commit/data.go
+++ b/datasource/commit/data.go
@@ -114,7 +114,7 @@ func (d *Datasource) Execute() (cty.Value, error) {
 	output.Committer = commit.Committer.String()
 	log.Printf("output.Committer: '%s'\n", output.Committer)
 
-	output.Timestamp = commit.Committer.When.Format(time.RFC3339)
+	output.Timestamp = commit.Committer.When.UTC().Format(time.RFC3339)
 	log.Printf("output.Timestamp: '%s'\n", output.Timestamp)
 
 	output.PGPSignature = commit.PGPSignature

--- a/datasource/commit/data.go
+++ b/datasource/commit/data.go
@@ -5,6 +5,7 @@ package commit
 
 import (
 	"log"
+	"time"
 
 	"github.com/ethanmdavidson/packer-plugin-git/common"
 	"github.com/go-git/go-git/v5"
@@ -29,6 +30,7 @@ type DatasourceOutput struct {
 	Branches     []string `mapstructure:"branches"`
 	Author       string   `mapstructure:"author"`
 	Committer    string   `mapstructure:"committer"`
+	Timestamp    string   `mapstructure:"timestamp"`
 	PGPSignature string   `mapstructure:"pgp_signature"`
 	Message      string   `mapstructure:"message"`
 	TreeHash     string   `mapstructure:"tree_hash"`
@@ -111,6 +113,9 @@ func (d *Datasource) Execute() (cty.Value, error) {
 
 	output.Committer = commit.Committer.String()
 	log.Printf("output.Committer: '%s'\n", output.Committer)
+
+	output.Timestamp = commit.Committer.When.Format(time.RFC3339)
+	log.Printf("output.Timestamp: '%s'\n", output.Timestamp)
 
 	output.PGPSignature = commit.PGPSignature
 	log.Printf("len(output.PGPSignature): '%d'\n", len(output.PGPSignature))

--- a/datasource/commit/data.hcl2spec.go
+++ b/datasource/commit/data.hcl2spec.go
@@ -39,6 +39,7 @@ type FlatDatasourceOutput struct {
 	Branches     []string `mapstructure:"branches" cty:"branches" hcl:"branches"`
 	Author       *string  `mapstructure:"author" cty:"author" hcl:"author"`
 	Committer    *string  `mapstructure:"committer" cty:"committer" hcl:"committer"`
+	Timestamp    *string  `mapstructure:"timestamp" cty:"timestamp" hcl:"timestamp"`
 	PGPSignature *string  `mapstructure:"pgp_signature" cty:"pgp_signature" hcl:"pgp_signature"`
 	Message      *string  `mapstructure:"message" cty:"message" hcl:"message"`
 	TreeHash     *string  `mapstructure:"tree_hash" cty:"tree_hash" hcl:"tree_hash"`
@@ -61,6 +62,7 @@ func (*FlatDatasourceOutput) HCL2Spec() map[string]hcldec.Spec {
 		"branches":      &hcldec.AttrSpec{Name: "branches", Type: cty.List(cty.String), Required: false},
 		"author":        &hcldec.AttrSpec{Name: "author", Type: cty.String, Required: false},
 		"committer":     &hcldec.AttrSpec{Name: "committer", Type: cty.String, Required: false},
+		"timestamp":     &hcldec.AttrSpec{Name: "timestamp", Type: cty.String, Required: false},
 		"pgp_signature": &hcldec.AttrSpec{Name: "pgp_signature", Type: cty.String, Required: false},
 		"message":       &hcldec.AttrSpec{Name: "message", Type: cty.String, Required: false},
 		"tree_hash":     &hcldec.AttrSpec{Name: "tree_hash", Type: cty.String, Required: false},

--- a/datasource/commit/data_acc_test.go
+++ b/datasource/commit/data_acc_test.go
@@ -52,6 +52,7 @@ func TestAccGitCommitDatasource(t *testing.T) {
 			branchLog := "null.basic-example: num_branches: [0-9]*"
 			authorLog := "null.basic-example: author: [^\\n]*<[^\\n]*>"
 			committerLog := "null.basic-example: committer: [^\\n]*<[^\\n]*>"
+			timestampLog := "null.basic-example: timestamp: \\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z"
 			//Can't test pgp_signature since that isn't set on most of my commits
 			messageLog := "null.basic-example: message: .*"
 			treeHashLog := "null.basic-example: tree_hash: [0-9a-f]{5,40}"
@@ -61,6 +62,7 @@ func TestAccGitCommitDatasource(t *testing.T) {
 			checkMatch(t, logsString, "num_branches", branchLog)
 			checkMatch(t, logsString, "author", authorLog)
 			checkMatch(t, logsString, "committer", committerLog)
+			checkMatch(t, logsString, "timestamp", timestampLog)
 			checkMatch(t, logsString, "message", messageLog)
 			checkMatch(t, logsString, "tree_hash", treeHashLog)
 			checkMatch(t, logsString, "first_parent", parentLog)

--- a/datasource/commit/test-fixtures/template.pkr.hcl
+++ b/datasource/commit/test-fixtures/template.pkr.hcl
@@ -23,6 +23,7 @@ build {
       "echo 'num_branches: ${length(data.git-commit.test.branches)}'",
       "echo 'author: ${data.git-commit.test.author}'",
       "echo 'committer: ${data.git-commit.test.committer}'",
+      "echo 'timestamp: ${data.git-commit.test.timestamp}'",
       "echo 'pgp_signature: ${data.git-commit.test.pgp_signature}'",
       "echo 'message: ${local.message}'",
       "echo 'tree_hash: ${data.git-commit.test.tree_hash}'",

--- a/docs/datasources/commit.mdx
+++ b/docs/datasources/commit.mdx
@@ -37,6 +37,7 @@ for the list of supported values. Defaults to 'HEAD'.
 - `branches` (string) - The short names of branches at the selected commit.
 - `author` (string) - The author of the commit, in standard `A U Thor <author@example.com>` format.
 - `committer` (string) - The committer of the commit, in same format as author.
+- `timestamp` (string) - The timestamp of the commit, in RFC3339 format.
 - `pgp_signature` (string) - The PGP signature attached to the commit.
 - `message` (string) - The commit message.
 - `tree_hash` (string) - The hash of the root tree of the commit.

--- a/docs/datasources/commit.mdx
+++ b/docs/datasources/commit.mdx
@@ -37,7 +37,7 @@ for the list of supported values. Defaults to 'HEAD'.
 - `branches` (string) - The short names of branches at the selected commit.
 - `author` (string) - The author of the commit, in standard `A U Thor <author@example.com>` format.
 - `committer` (string) - The committer of the commit, in same format as author.
-- `timestamp` (string) - The timestamp of the commit, in RFC3339 format.
+- `timestamp` (string) - The timestamp of the commit, in RFC3339 format (e.g. `2024-01-02T09:38:19Z`).
 - `pgp_signature` (string) - The PGP signature attached to the commit.
 - `message` (string) - The commit message.
 - `tree_hash` (string) - The hash of the root tree of the commit.

--- a/example/commit.pkr.hcl
+++ b/example/commit.pkr.hcl
@@ -23,6 +23,7 @@ build {
       "echo 'branches: ${local.branchesString}'",
       "echo 'author: ${data.git-commit.test.author}'",
       "echo 'committer: ${data.git-commit.test.committer}'",
+      "echo 'timestamp: ${data.git-commit.test.timestamp}'",
       "echo 'pgp_signature: ${data.git-commit.test.pgp_signature}'",
       "echo 'message: ${local.message}'",
       "echo 'tree_hash: ${data.git-commit.test.tree_hash}'",


### PR DESCRIPTION
This small addition exposes the timestamp of a commit as an RFC3339 formatted string. 