### PR TITLE
GNUmakefile: make dev uses packer for install

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,5 +1,6 @@
 NAME=git
 BINARY=packer-plugin-${NAME}
+PLUGIN_FQN="$(shell grep -E '^module' <go.mod | sed -E 's/module *//')"
 HASHICORP_PACKER_PLUGIN_SDK_VERSION?=$(shell go list -m github.com/hashicorp/packer-plugin-sdk | cut -d " " -f2)
 
 COUNT?=1
@@ -11,9 +12,9 @@ prep: phony
 build: phony
 	@go build -o ${BINARY}
 
-dev: phony build
-	@mkdir -p ~/.packer.d/plugins/
-	@mv ${BINARY} ~/.packer.d/plugins/${BINARY}
+dev: phony
+	@go build -ldflags="-X '${PLUGIN_FQN}/version.VersionPrerelease=dev'" -o '${BINARY}'
+	packer plugins install --path ${BINARY} "$(shell echo "${PLUGIN_FQN}" | sed 's/packer-plugin-//')"
 
 run-example: phony dev
 	@packer build ./example

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ The typical development flow looks something like this:
 6) Once the above steps are complete: commit, push, and open a PR!
 
 For local development, you will need to install:
-- [Packer](https://learn.hashicorp.com/tutorials/packer/get-started-install-cli) >= 1.7
+- [Packer](https://learn.hashicorp.com/tutorials/packer/get-started-install-cli) >= 1.10.2
 - [Go](https://golang.org/doc/install) >= 1.21
 - [GNU Make](https://www.gnu.org/software/make/)
 


### PR DESCRIPTION
When building the development version of the plugin, we now use
`packer plugins install` for that instead of moving it to the plugins
directory manually.

This target will require Packer 1.10.2 and above to function, as prior
versions don't support instaling pre-release versions of a plugin with
that command.
