### PR TITLE
v0.6.5 fixup

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0
         with:
-          version: latest
+          version: "~> v2"
           args: release --clean
         env:
           GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -27,7 +27,10 @@ jobs:
         run: make prep
 
       - name: Execute tests
-        run: make test && make testacc
+        run: |
+          make test
+          make testacc
+          make test-releaser
 
       - name: Upload test artifacts for debugging
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -37,8 +37,10 @@ builds:
       - darwin
     goarch:
       - amd64
-      - '386'
-      - arm
+      # 32-bit builds are disabled for now because of https://github.com/ulikunitz/xz/issues/62
+      # Not going to revert xz because 0.5.14 was a vuln fix, and I don't think anyone is using these archs anyway.
+      #- '386'
+      #- arm
       - arm64
     ignore:
       - goos: darwin

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -37,10 +37,8 @@ builds:
       - darwin
     goarch:
       - amd64
-      # 32-bit builds are disabled for now because of https://github.com/ulikunitz/xz/issues/62
-      # Not going to revert xz because 0.5.14 was a vuln fix, and I don't think anyone is using these archs anyway.
-      #- '386'
-      #- arm
+      - '386'
+      - arm
       - arm64
     ignore:
       - goos: darwin

--- a/go.mod
+++ b/go.mod
@@ -67,7 +67,7 @@ require (
 	github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3 // indirect
 	github.com/skeema/knownhosts v1.3.1 // indirect
 	github.com/ugorji/go/codec v1.2.12 // indirect
-	github.com/ulikunitz/xz v0.5.14 // indirect
+	github.com/ulikunitz/xz v0.5.15 // indirect
 	github.com/vmihailenco/msgpack/v5 v5.4.1 // indirect
 	github.com/vmihailenco/tagparser/v2 v2.0.0 // indirect
 	github.com/xanzy/ssh-agent v0.3.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -273,8 +273,8 @@ github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=
 github.com/ugorji/go/codec v1.2.12 h1:9LC83zGrHhuUA9l16C9AHXAqEV/2wBQ4nkvumAE65EE=
 github.com/ugorji/go/codec v1.2.12/go.mod h1:UNopzCgEMSXjBc6AOMqYvWC1ktqTAfzJZUZgYf6w6lg=
-github.com/ulikunitz/xz v0.5.14 h1:uv/0Bq533iFdnMHZdRBTOlaNMdb1+ZxXIlHDZHIHcvg=
-github.com/ulikunitz/xz v0.5.14/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
+github.com/ulikunitz/xz v0.5.15 h1:9DNdB5s+SgV3bQ2ApL10xRc35ck0DuIX/isZvIk+ubY=
+github.com/ulikunitz/xz v0.5.15/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
 github.com/vmihailenco/msgpack/v5 v5.4.1 h1:cQriyiUvjTwOHg8QZaPihLWeRAAVoCpE00IUPn0Bjt8=
 github.com/vmihailenco/msgpack/v5 v5.4.1/go.mod h1:GaZTsDaehaPpQVyxrf5mtQlH+pc21PIudVV/E3rRQok=
 github.com/vmihailenco/tagparser/v2 v2.0.0 h1:y09buUbR+b5aycVFQs/g70pqKVZNBmxwAhO7/IwNM9g=


### PR DESCRIPTION
[The release process for v0.6.5 failed](https://github.com/ethanmdavidson/packer-plugin-git/actions/runs/17306793206) due to a bug in one of the dependencies. The workaround is to disable 32-bit builds. I'm on the fence about whether to do that, or instead roll back the dep.

On one hand, [the failing dep version is a vuln fix](https://github.com/ethanmdavidson/packer-plugin-git/security/dependabot/20) and I think it's unlikely anyone is using this plugin on arm or 386. 

On the other hand, the vuln seems like it's probably not a big deal for this plugin, since it only affects availability and requires operating on untrusted data.

I think I will hold this PR for a week since it seems like [the bug](https://github.com/ulikunitz/xz/issues/62) should be fixed quickly. If it's not fixed within a week, I'll proceed with disabling 32-bit builds.